### PR TITLE
Make pod priority settings configurable in orchestra charts

### DIFF
--- a/charts/crate/Chart.yaml
+++ b/charts/crate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'CrateDB chart'
 name: crate
-version: 0.1.8
+version: 0.1.9
 icon: https://crate.io/wp-content/themes/webflow/images/logo-crate.png
 sources:
 - https://github.com/crate/crate

--- a/charts/crate/README.MD
+++ b/charts/crate/README.MD
@@ -52,6 +52,8 @@ The following table lists the configurable parameters of the patroni chart and t
 | `nodeSelector`                    | Crate Node labels for pod assignment        | {}                                                  |
 | `tolerations`                     | Toleration labels for Crate pod assignment  | []                                                  |
 | `affinity`                        | Affinity settings for Crate pod assignment  | {}                                                  |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/charts/crate/templates/statefulset.yaml
+++ b/charts/crate/templates/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds}}
       initContainers:
       - name: init-sysctl

--- a/charts/datacollector/Chart.yaml
+++ b/charts/datacollector/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy streamsets data datacollector
 name: datacollector
-version: 0.1.7
+version: 0.1.8

--- a/charts/datacollector/README.MD
+++ b/charts/datacollector/README.MD
@@ -46,6 +46,7 @@ Collector chart and their default values.
 | `persistentVolume.annotations`    | Annotations for Persistent Volume Claim`    | `{}`                                                |
 | `persistentVolume.size`           | Persistent Volume size                      | `4Gi`                                               |
 | `persistentVolume.storageClass`   | Persistent Volume Storage Class             | `default` |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/datacollector/templates/statefulset.yaml
+++ b/charts/datacollector/templates/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds}}
       initContainers:
        - name: init-datacollector-data

--- a/charts/iot-agent-manager/Chart.yaml
+++ b/charts/iot-agent-manager/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for IoT Agent Manager
 name: iot-agent-manager
-version: 0.1.3
+version: 0.1.4

--- a/charts/iot-agent-manager/README.MD
+++ b/charts/iot-agent-manager/README.MD
@@ -37,6 +37,7 @@ chart and their default values.
 | `image.repository`                | The image to pull                           | `fiware/iotagent-ul`                                      |
 | `image.tag`                       | The version of the image to pull            | `1.9.0`                                             |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/iot-agent-manager/templates/deployment.yaml
+++ b/charts/iot-agent-manager/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app: {{ template "iot-agent-manager.name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/iot-agent/Chart.yaml
+++ b/charts/iot-agent/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for NodeJS based IoT Agents
 name: iot-agent
-version: 0.1.6
+version: 0.1.7

--- a/charts/iot-agent/README.MD
+++ b/charts/iot-agent/README.MD
@@ -50,6 +50,7 @@ chart and their default values.
 | `service.defaultSubservice`       | default subservice for the IoT Agent. If a device is being registered, and no subservice information comes with the device data, and no subservice information is configured for the given type, the default IoT agent subservice will be used instead. | '/' |
 | `service.providerUrl`             | URL to send in the Context Provider registration requests. Should represent the external IP of the deployed IoT Agent (the IP where the Context Broker will redirect the NGSI requests) | 'http://ul-iot-agent:4041' |
 | `service.deviceRegistrationDuration`          | duration of the registrations as Context Providers, in ISO 8601 standard format. | P1M |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/iot-agent/templates/deployment.yaml
+++ b/charts/iot-agent/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         component: "{{ .Values.service.agentType }}"
         release: {{ .Release.Name }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       {{ if eq .Values.service.agentType "lwm2m" }}
       hostAliases:
         - ip: "100.122.0.5"

--- a/charts/nosqlclient/Chart.yaml
+++ b/charts/nosqlclient/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "2.2.0"
 description: A Helm chart to deploy nosql client
 name: nosqlclient
-version: 0.1.2
+version: 0.1.3

--- a/charts/nosqlclient/README.MD
+++ b/charts/nosqlclient/README.MD
@@ -44,6 +44,7 @@ NoSQL Client chart and their default values.
 | `nodeSelector`                    | Node labels for pod assignment              | `{}`                                                |
 | `affinity`                        | Pod affinity. Passed through the `tpl` function and thus to be configured a string | `Hard node and soft zone anti-affinity`|
 | `tolerations`                     | Node taints to tolerate                     | `[]`                                                |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/nosqlclient/templates/deployment.yaml
+++ b/charts/nosqlclient/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app.kubernetes.io/name: {{ include "nosqlclient.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Orion Context Broker
 name: orion
-version: 0.1.4
+version: 0.1.5
 sources:
 - https://github.com/telefonicaid/fiware-orion
 maintainers:

--- a/charts/orion/README.MD
+++ b/charts/orion/README.MD
@@ -38,6 +38,7 @@ Orion Context Broker chart and their default values.
 | `image.tag`                       | The version of the image to pull            | `2.2.0`                                             |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/orion/templates/deployment.yaml
+++ b/charts/orion/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ template "orion.name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+
       initContainers:
         - name: create-indexes
           image: {{ .Values.mongo.image }}

--- a/charts/quantumleap/Chart.yaml
+++ b/charts/quantumleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for QuantumLeap
 name: quantumleap
-version: 0.1.10
+version: 0.1.11
 sources:
 - https://github.com/smartsdk/ngsi-timeseries-api
 maintainers:

--- a/charts/quantumleap/README.MD
+++ b/charts/quantumleap/README.MD
@@ -58,6 +58,7 @@ The following table lists the configurable parameters of the patroni chart and t
 |                                   |                                             | `  t2:`                                             |
 |                                   |                                             | `      backend: Crate`                              |
 |                                   |                                             | `default-backend: Crate`                            |
+| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/quantumleap/templates/deployment.yaml
+++ b/charts/quantumleap/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app: {{ template "quantumleap.name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.init }}
       initContainers:
         - name: init-postgresql


### PR DESCRIPTION
This PR makes `priorityClassName` configurable in **all** current charts. In fact, we might need to specify priorities for services other than Orion, QL, and Crate since the default priority if not specified and there's no global default (i.e. there's no `PriorityClass` resource with `globalDefault: true`) becomes zero, which is the lowest possible. (See [K8s docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#notes-about-podpriority-and-existing-clusters) about it).

I picked up an issue with the IoT Agent chart that I initially thought was related to this PR's change set, but after rolling back the changes the issue was still there, so I opened a separate GH issue to tackle it some other time---see #62.
