### PR TITLE
fix helm3 not respecting HPA replicas

### DIFF
--- a/charts/iot-agent-manager/Chart.yaml
+++ b/charts/iot-agent-manager/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for IoT Agent Manager
 name: iot-agent-manager
-version: 0.1.6
+version: 0.1.7

--- a/charts/iot-agent-manager/templates/deployment.yaml
+++ b/charts/iot-agent-manager/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "iot-agent-manager.name" . }}
- {{- if not .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
   strategy:

--- a/charts/iot-agent-manager/templates/deployment.yaml
+++ b/charts/iot-agent-manager/templates/deployment.yaml
@@ -11,7 +11,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "iot-agent-manager.name" . }}
+ {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:

--- a/charts/iot-agent/Chart.yaml
+++ b/charts/iot-agent/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for NodeJS based IoT Agents
 name: iot-agent
-version: 0.1.14
+version: 0.1.15

--- a/charts/iot-agent/templates/deployment.yaml
+++ b/charts/iot-agent/templates/deployment.yaml
@@ -12,7 +12,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "iot-agent.name" . }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:

--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Orion Context Broker
 name: orion
-version: 0.1.6
+version: 0.1.7
 sources:
 - https://github.com/telefonicaid/fiware-orion
 maintainers:

--- a/charts/orion/templates/deployment.yaml
+++ b/charts/orion/templates/deployment.yaml
@@ -11,7 +11,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "orion.name" . }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:

--- a/charts/quantumleap/Chart.yaml
+++ b/charts/quantumleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for QuantumLeap
 name: quantumleap
-version: 0.1.17
+version: 0.1.18
 sources:
 - https://github.com/smartsdk/ngsi-timeseries-api
 maintainers:

--- a/charts/quantumleap/templates/deployment.yaml
+++ b/charts/quantumleap/templates/deployment.yaml
@@ -11,7 +11,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "quantumleap.name" . }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:


### PR DESCRIPTION
Helm3 replaces the replica count set by the HPA repeatedly, resulting in a up- and down-scaling loop.

Because of that it is necessary to update the helm charts.
https://github.com/helm/helm/issues/7090