### PR TITLE
Roll iotam and iota deployments if config has changed

### DIFF
--- a/charts/iot-agent-manager/Chart.yaml
+++ b/charts/iot-agent-manager/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for IoT Agent Manager
 name: iot-agent-manager
-version: 0.1.7
+version: 0.1.8

--- a/charts/iot-agent-manager/README.MD
+++ b/charts/iot-agent-manager/README.MD
@@ -5,12 +5,14 @@ This directory contains a Kubernetes chart to deploy an
 cluster using Deployment.
 
 ## Todo
-* Finalise README
+
+- Finalise README
 
 ## Chart Details
+
 This chart will do the following:
 
-* Implement a HA scalable IoT Agent Manager cluster using a Kubernetes Deployment.
+- Implement a HA scalable IoT Agent Manager cluster using a Kubernetes Deployment.
 
 ## Installing the Chart
 
@@ -31,14 +33,14 @@ TODO
 The following table lists the configurable parameters of the IoT Agent Manager
 chart and their default values.
 
-|       Parameter                   |           Description                       |                         Default                     |
-|-----------------------------------|---------------------------------------------|-----------------------------------------------------|
-| `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
-| `image.repository`                | The image to pull                           | `telefonicaiot/iotagent-manager`                                      |
-| `image.tag`                       | The version of the image to pull            | `1.13.0`                                             |
-| `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
-| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
-| `affinity`               | If specified, defines affinity rules  | ``                                                  |
+| Parameter           | Description                                | Default                          |
+| ------------------- | ------------------------------------------ | -------------------------------- |
+| `replicaCount`      | Amount of pods to spawn                    | `3`                              |
+| `image.repository`  | The image to pull                          | `telefonicaiot/iotagent-manager` |
+| `image.tag`         | The version of the image to pull           | `1.13.0`                         |
+| `image.pullPolicy`  | The pull policy                            | `IfNotPresent`                   |
+| `priorityClassName` | If specified, indicates the pod's priority | ``                               |
+| `affinity`          | If specified, defines affinity rules       | ``                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/iot-agent-manager/README.MD
+++ b/charts/iot-agent-manager/README.MD
@@ -34,8 +34,8 @@ chart and their default values.
 |       Parameter                   |           Description                       |                         Default                     |
 |-----------------------------------|---------------------------------------------|-----------------------------------------------------|
 | `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
-| `image.repository`                | The image to pull                           | `fiware/iotagent-ul`                                      |
-| `image.tag`                       | The version of the image to pull            | `1.9.0`                                             |
+| `image.repository`                | The image to pull                           | `telefonicaiot/iotagent-manager`                                      |
+| `image.tag`                       | The version of the image to pull            | `1.13.0`                                             |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
 | `affinity`               | If specified, defines affinity rules  | ``                                                  |

--- a/charts/iot-agent-manager/templates/autoscaler.yaml
+++ b/charts/iot-agent-manager/templates/autoscaler.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ template "iot-agent-manager.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "iot-agent-manager.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}

--- a/charts/iot-agent-manager/templates/deployment.yaml
+++ b/charts/iot-agent-manager/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
       labels:
         app: {{ template "iot-agent-manager.name" . }}

--- a/charts/iot-agent-manager/values.yaml
+++ b/charts/iot-agent-manager/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: telefonicaiot/iotagent-manager
-  tag: 1.6.0
+  tag: 1.13.0
   pullPolicy: IfNotPresent
 
 chaos:
@@ -37,7 +37,7 @@ mongo:
   # The name of the replicaset iot-agent will attempt to connect to
   rs: rs
   # The hostname of the mongodb service
-  dbhost: mongo-rs-mongodb-replicaset-0.mongo-rs-mongodb-replicaset.prod,mongo-rs-mongodb-replicaset-1.mongo-rs-mongodb-replicaset.prod,mongo-rs-mongodb-replicaset-2.mongo-rs-mongodb-replicaset.prod
+  dbhost: mongo-rs-mongodb-replicaset.prod
   # The database name to be used for the agent
   dbname: iot-agent-manager
   # The database name to be used for the agent

--- a/charts/iot-agent/Chart.yaml
+++ b/charts/iot-agent/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for NodeJS based IoT Agents
 name: iot-agent
-version: 0.1.15
+version: 0.1.16

--- a/charts/iot-agent/README.MD
+++ b/charts/iot-agent/README.MD
@@ -3,20 +3,23 @@
 This directory contains a Kubernetes chart to deploy an IoT Agent cluster using
 Deployment. IoT Agents supported are:
 
-* [UL](https://github.com/telefonicaid/iotagent-ul) v1.13
-* [JSON](https://github.com/telefonicaid/iotagent-json) v1.14
-* [LORAWAN](https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN)
+- [UL](https://github.com/telefonicaid/iotagent-ul) v1.13
+- [JSON](https://github.com/telefonicaid/iotagent-json) v1.14
+- [LORAWAN](https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN)
 
 ## Prerequisites Details
-* Kubernetes 1.9+
+
+- Kubernetes 1.9+
 
 ## Todo
-* Finalise README
+
+- Finalise README
 
 ## Chart Details
+
 This chart will do the following:
 
-* Implement a HA scalable IoT Agent cluster using a Kubernetes Deployment.
+- Implement a HA scalable IoT Agent cluster using a Kubernetes Deployment.
 
 ## Installing the Chart
 
@@ -37,25 +40,25 @@ TODO
 The following table lists the configurable parameters of the IoT Agent
 chart and their default values.
 
-|       Parameter                   |           Description                       |                         Default                     |
-|-----------------------------------|---------------------------------------------|-----------------------------------------------------|
-| `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
-| `image.repository`                | The image to pull                           | `fiware/iotagent-ul`                                      |
-| `image.tag`                       | The version of the image to pull            | `1.9.0`                                             |
-| `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
-| `service.agentType`               | The type of agent deployed | `ul`                                                |
-| `service.name`                    | Name of the service deployed | `iotagent-ul`                                                |
-| `service.timestamp`               | If this flag is activated, the IoT Agent will add a 'TimeInstant' metadata attribute to all the attributes updated from device information. | `true`
-| `service.defaultService`          | default service for the IoT Agent. If a device is being registered, and no service information comes with the device data, and no service information is configured for the given type, the default IoT agent service will be used instead. | `Default` |
-| `service.defaultSubservice`       | default subservice for the IoT Agent. If a device is being registered, and no subservice information comes with the device data, and no subservice information is configured for the given type, the default IoT agent subservice will be used instead. | '/' |
-| `service.providerUrl`             | URL to send in the Context Provider registration requests. Should represent the external IP of the deployed IoT Agent (the IP where the Context Broker will redirect the NGSI requests) | 'http://ul-iot-agent:4041' |
-| `service.deviceRegistrationDuration`          | duration of the registrations as Context Providers, in ISO 8601 standard format. | P1M |
-| `priorityClassName`               | If specified, indicates the pod's priority  | ``                                                  |
-| `affinity`               | If specified, defines affinity rules  | ``                                                  |
+| Parameter                            | Description                                                                                                                                                                                                                                             | Default                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `replicaCount`                       | Amount of pods to spawn                                                                                                                                                                                                                                 | `3`                        |
+| `image.repository`                   | The image to pull                                                                                                                                                                                                                                       | `fiware/iotagent-ul`       |
+| `image.tag`                          | The version of the image to pull                                                                                                                                                                                                                        | `1.9.0`                    |
+| `image.pullPolicy`                   | The pull policy                                                                                                                                                                                                                                         | `IfNotPresent`             |
+| `service.agentType`                  | The type of agent deployed                                                                                                                                                                                                                              | `ul`                       |
+| `service.name`                       | Name of the service deployed                                                                                                                                                                                                                            | `iotagent-ul`              |
+| `service.timestamp`                  | If this flag is activated, the IoT Agent will add a 'TimeInstant' metadata attribute to all the attributes updated from device information.                                                                                                             | `true`                     |
+| `service.defaultService`             | default service for the IoT Agent. If a device is being registered, and no service information comes with the device data, and no service information is configured for the given type, the default IoT agent service will be used instead.             | `Default`                  |
+| `service.defaultSubservice`          | default subservice for the IoT Agent. If a device is being registered, and no subservice information comes with the device data, and no subservice information is configured for the given type, the default IoT agent subservice will be used instead. | '/'                        |
+| `service.providerUrl`                | URL to send in the Context Provider registration requests. Should represent the external IP of the deployed IoT Agent (the IP where the Context Broker will redirect the NGSI requests)                                                                 | 'http://ul-iot-agent:4041' |
+| `service.deviceRegistrationDuration` | duration of the registrations as Context Providers, in ISO 8601 standard format.                                                                                                                                                                        | P1M                        |
+| `priorityClassName`                  | If specified, indicates the pod's priority                                                                                                                                                                                                              | ``                         |
+| `affinity`                           | If specified, defines affinity rules                                                                                                                                                                                                                    | ``                         |
 
 > **NOTE**: Be careful with enabling `multiCore: true` on k8s running on top of aws nodes.
-We witnessed processors constantly spawn and killed, without any instance 
-remaining active.
+> We witnessed processors constantly spawn and killed, without any instance
+> remaining active.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -67,8 +70,8 @@ $ helm install --name my-release -f values.yaml oc/iot-agent
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-> **Tip**: Use `service.agentType` to define the type of agent to that 
-agent specific configuration is applied
+> **Tip**: Use `service.agentType` to define the type of agent to that
+> agent specific configuration is applied
 
 ## Cleanup
 

--- a/charts/iot-agent/templates/autoscaler.yaml
+++ b/charts/iot-agent/templates/autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "iot-agent.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "iot-agent.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}

--- a/charts/iot-agent/templates/deployment.yaml
+++ b/charts/iot-agent/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-" .Values.agent.agentType ".yaml") . | sha256sum }}
         chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
       labels:
         app: {{ template "iot-agent.name" . }}


### PR DESCRIPTION
- Added a configmap hash to IOTA and IOTAM deployments so the deployments get rolled if the config changes
- Bumped IOTAM version in Readme and values.yaml to the latest stable one (works fine)
- Replaced the mongo host in the values of the IOTAM chart with the service name, as since a few versions the IOTAM can connect to a mongo replicaset without specifying each member seperately
- replaced deployment apiVersion `apps/v1beta1` with `apps/v1` in autoscaler