### PR TITLE
add a possibility to hide postgres passwords for quantumleap

### DIFF
--- a/charts/quantumleap/Chart.yaml
+++ b/charts/quantumleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for QuantumLeap
 name: quantumleap
-version: 0.1.18
+version: 0.1.19
 sources:
 - https://github.com/smartsdk/ngsi-timeseries-api
 maintainers:

--- a/charts/quantumleap/templates/deployment.yaml
+++ b/charts/quantumleap/templates/deployment.yaml
@@ -36,9 +36,23 @@ spec:
           - name: PG_HOST
             value: {{ .Values.database.timescale.host }}
           - name: PG_PASS
+            {{- if .Values.init.passwordSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.init.passwordSecret }}
+                key: password
+            {{- else }}
             value: {{ .Values.init.password }}
+            {{- end }}
           - name: QL_DB_PASS
+            {{- if .Values.database.timescale.passwordSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.timescale.passwordSecret }}
+                key: password
+            {{- else }}
             value: {{ .Values.database.timescale.password }}
+            {{- end }}
           - name: QL_DB_INIT_DIR
             value: "/init"
           resources:
@@ -75,7 +89,14 @@ spec:
           - name: POSTGRES_DB_USER
             value: {{ .Values.database.timescale.user }}
           - name: POSTGRES_DB_PASS
+            {{- if .Values.database.timescale.passwordSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.timescale.passwordSecret }}
+                key: password
+            {{- else }}
             value: {{ .Values.database.timescale.password }}
+            {{- end }}
 {{- if .Values.database.timescale.ssl }}
           - name: POSTGRES_USE_SSL
             value: t

--- a/charts/quantumleap/values.yaml
+++ b/charts/quantumleap/values.yaml
@@ -73,6 +73,8 @@ database:
     name: quantumleap
     user: quantumleap
     password: quantumleap
+    # Secret must be set manually in the namespace and overrides the above set password if provided. Key has to be "password".
+    # passwordSecret: quantumleap-pg-timescale
     ssl: true
 
 runtime:
@@ -93,6 +95,8 @@ config:
 
 init:
   password: password
+  # Secret must be set manually in the namespace and overrides the above set password if provided. Key has to be "password".
+  # passwordSecret: quantumleap-pg-init
   image:
     repository: smartsdk/quantumleap-pg-init
     tag: latest


### PR DESCRIPTION
This change provides a possibility to set the postgres password env vars via secrets to avoid using them in plain text. This is especially helpful if managed in git repositories.