### PR TITLE
Anubis Management API chart

### DIFF
--- a/charts/anubis-management-api/.helmignore
+++ b/charts/anubis-management-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/anubis-management-api/Chart.yaml
+++ b/charts/anubis-management-api/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: A Helm chart for the Anubis management API
+name: anubis-management-api
+version: 0.1.0
+sources:
+- https://github.com/orchestracities/anubis
+maintainers:
+- name: c0c0n3

--- a/charts/anubis-management-api/README.md
+++ b/charts/anubis-management-api/README.md
@@ -1,0 +1,52 @@
+# Anubis Management API Helm Chart
+
+This directory contains a Helm chart to deploy the [Anubis][anubis]
+Management API to a Kubernetes cluster.
+
+## Prerequisites
+- Kubernetes `>= 1.20`
+- Helm `>= 2.16`
+
+## Chart details
+This Helm chart deploys the [Anubis][anubis] Management API to a
+Kubernetes cluster. Use this chart to make the Anubis database
+available through a REST API. Notice this chart is quite basic at
+the moment and it doesn't cater for any other Anubis component
+like OPA rules and distribution middleware.
+
+## Installing the Chart
+To install the chart with the release name `my-release`, run
+
+```bash
+$ helm repo add oc https://orchestracities.github.io/charts/
+$ helm dependency update
+$ helm install --name my-release oc/anubis-management-api
+```
+
+## Configuration
+This chart provides the usual Helm parameters plus an `env` stanza
+to let you specify any environment variables for the Anubis Management
+API pod. Have a look at the default [values.yaml][values] file bundled
+with the chart to see what you can configure exactly.
+
+Specify each parameter using the `--set key=value[,key=value]`
+argument to `helm install`. Alternatively, provide a YAML file
+with parameter values when installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml oc/anubis-management-api
+```
+
+## Cleanup
+To remove the pods and Kubernetes resources the chart installed, run
+a `helm delete <release-name>` as in the example below.
+
+```bash
+$ helm delete my-release
+```
+
+
+
+
+[anubis]: https://github.com/orchestracities/anubis
+[values]: ./values.yaml

--- a/charts/anubis-management-api/templates/NOTES.txt
+++ b/charts/anubis-management-api/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "anubis-management-api.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "anubis-management-api.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "anubis-management-api.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "anubis-management-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/anubis-management-api/templates/_helpers.tpl
+++ b/charts/anubis-management-api/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "anubis-management-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anubis-management-api.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/anubis-management-api/templates/autoscaler.yaml
+++ b/charts/anubis-management-api/templates/autoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "anubis-management-api.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "anubis-management-api.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ template "anubis-management-api.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.autoscaling.targetAverageUtilization }}
+{{- end }}

--- a/charts/anubis-management-api/templates/deployment.yaml
+++ b/charts/anubis-management-api/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: "apps/v1"
+kind: Deployment
+metadata:
+  name: {{ template "anubis-management-api.fullname" . }}
+  labels:
+    app: {{ template "anubis-management-api.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anubis-management-api.name" . }}
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  template:
+    metadata:
+      annotations:
+        chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+      labels:
+        app: {{ template "anubis-management-api.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/charts/anubis-management-api/templates/deployment.yaml
+++ b/charts/anubis-management-api/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          env:
+{{ toYaml .Values.env | indent 12 }}
           livenessProbe:
             httpGet:
               path: /ping

--- a/charts/anubis-management-api/templates/ingress.yaml
+++ b/charts/anubis-management-api/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "anubis-management-api.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "anubis-management-api.fullname" . }}
+  labels:
+    app: {{ template "anubis-management-api.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/anubis-management-api/templates/service.yaml
+++ b/charts/anubis-management-api/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anubis-management-api.fullname" . }}
+  labels:
+    app: {{ template "anubis-management-api.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "anubis-management-api.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/anubis-management-api/values.yaml
+++ b/charts/anubis-management-api/values.yaml
@@ -9,6 +9,24 @@ image:
   pullPolicy: IfNotPresent
   tag: "0.6.0"
 
+env:
+- name: DB_TYPE
+  value: postgres
+- name: DB_HOST
+  value: acid-oc-cluster
+- name: DB_NAME
+  value: anubis
+- name: DB_USER
+  valueFrom:
+    secretKeyRef:
+      name: anubis.acid-oc-cluster.credentials.postgresql.acid.zalan.do
+      key: username
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: anubis.acid-oc-cluster.credentials.postgresql.acid.zalan.do
+      key: password
+
 chaos:
   enabled: false
 

--- a/charts/anubis-management-api/values.yaml
+++ b/charts/anubis-management-api/values.yaml
@@ -1,0 +1,54 @@
+# Default values for anubis-management-api.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: orchestracities/anubis-management-api
+  pullPolicy: IfNotPresent
+  tag: "0.6.0"
+
+chaos:
+  enabled: false
+
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
+  type: RollingUpdate
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 4
+  targetAverageUtilization: 50
+
+service:
+  name: anubis-management-api
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8000
+
+affinity: {}
+
+ingress:
+  enabled: false
+  # Used to create an Ingress record.
+  hosts:
+    - anubis-management-api.example.com
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls: {}
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 128Mi

--- a/charts/anubis-management-api/values.yaml
+++ b/charts/anubis-management-api/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: orchestracities/anubis-management-api
   pullPolicy: IfNotPresent
-  tag: "0.6.0"
+  tag: "0.7.0"
 
 env:
 - name: DB_TYPE


### PR DESCRIPTION
This PR implements a basic Helm chart to deploy the Anubis Management API to a Kubernetes cluster. The chart basically makes the Anubis database available through a REST API. Notice the chart is quite basic at the moment and it doesn't cater for any other Anubis component like OPA rules and distribution middleware.